### PR TITLE
Fix TypeScript type error in AppointmentForm

### DIFF
--- a/components/forms/AppointmentForm.tsx
+++ b/components/forms/AppointmentForm.tsx
@@ -93,7 +93,7 @@ export const AppointmentForm = ({
       } else {
         const appointmentToUpdate = {
           userId,
-          appointmentId: appointment?.$id,
+          appointmentId: appointment?.$id ?? "",
           appointment: {
             primaryPhysician: values.primaryPhysician,
             schedule: new Date(values.schedule),


### PR DESCRIPTION
Fix TypeScript type error in `components/forms/AppointmentForm.tsx`.

* Modify the `appointmentToUpdate` object to include a default empty string for `appointmentId` if it is undefined.
* Ensure `appointmentId` is always a string before passing it to `updateAppointment`.

